### PR TITLE
[Feature] Add decorators to the request handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": ">=7.1",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/support": "^5.4",
         "phpunit/phpunit": "~6.0|~7.0"

--- a/src/Contracts/RequestHandler.php
+++ b/src/Contracts/RequestHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace JSHayes\FakeRequests\Contracts;
+
+use GuzzleHttp\Psr7\Uri;
+use JSHayes\FakeRequests\Request;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface RequestHandler
+{
+    /**
+     * Get the Uri for this request handler
+     *
+     * @return \GuzzleHttp\Psr7\Uri
+     */
+    public function getUri(): Uri;
+
+    /**
+     * Get the request method for this request handler
+     *
+     * @return string
+     */
+    public function getMethod(): string;
+
+    /**
+     * Determine if this request should be handled
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     * @param arrar $options
+     * @return bool
+     */
+    public function shouldHandle(RequestInterface $request, array $options): bool;
+
+    /**
+     * Pass the request to the request inspector if specified, then return the
+     * response.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     * @param array $options
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function handle(RequestInterface $request, array $options): ResponseInterface;
+
+    /**
+     * Add a callback that will have the request and request options passed to
+     * it
+     *
+     * @param callable $callback
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function inspectRequest(callable $callback): RequestHandler;
+
+    /**
+     * Set the callback that determines when this request should be handled
+     *
+     * @param callable $callback
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function when(callable $callback): RequestHandler;
+
+    /**
+     * Add a response that this handler will response with.
+     *
+     * @param \Psr\Http\Message\ResponseInterface|callable|int $arg
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function respondWith($arg): RequestHandler;
+
+    /**
+     * Return the request that this handler handled
+     *
+     * @return \JSHayes\FakeRequests\Request|null
+     */
+    public function getRequest(): ?Request;
+}

--- a/src/Decorator.php
+++ b/src/Decorator.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace JSHayes\FakeRequests;
+
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use JSHayes\FakeRequests\Contracts\RequestHandler as RequestHandlerContract;
+
+abstract class Decorator implements RequestHandlerContract
+{
+    private $handler;
+
+    /**
+     * Decorate the given request handler
+     *
+     * @param \JSHayes\FakeRequests\Contracts\RequestHandler $handler
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function decorate(RequestHandlerContract $handler): RequestHandlerContract
+    {
+        $decorator = new static();
+        $decorator->handler = $handler;
+        return $decorator;
+    }
+
+    /**
+     * Get the Uri for this request handler
+     *
+     * @return \GuzzleHttp\Psr7\Uri
+     */
+    public function getUri(): Uri
+    {
+        return $this->handler->getUri();
+    }
+
+    /**
+     * Get the request method for this request handler
+     *
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return $this->handler->getMethod();
+    }
+
+    /**
+     * Determine if this request should be handled
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     * @param arrar $options
+     * @return bool
+     */
+    public function shouldHandle(RequestInterface $request, array $options): bool
+    {
+        return $this->handler->shouldHandle($request, $options);
+    }
+
+    /**
+     * Pass the request to the request inspector if specified, then return the
+     * response.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     * @param array $options
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function handle(RequestInterface $request, array $options): ResponseInterface
+    {
+        return $this->handler->handle($request, $options);
+    }
+
+    /**
+     * Add a callback that will have the request and request options passed to
+     * it
+     *
+     * @param callable $callback
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function inspectRequest(callable $callback): RequestHandlerContract
+    {
+        $this->handler->inspectRequest($callback);
+        return $this;
+    }
+
+    /**
+     * Set the callback that determines when this request should be handled
+     *
+     * @param callable $callback
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function when(callable $callback): RequestHandlerContract
+    {
+        $this->handler->when($callback);
+        return $this;
+    }
+
+    /**
+     * Add a response that this handler will response with.
+     *
+     * @param \Psr\Http\Message\ResponseInterface|callable|int $arg
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
+     */
+    public function respondWith($arg): RequestHandlerContract
+    {
+        $this->handler->respondWith(...func_get_args());
+        return $this;
+    }
+
+    /**
+     * Return the request that this handler handled
+     *
+     * @return \JSHayes\FakeRequests\Request|null
+     */
+    public function getRequest(): ?Request
+    {
+        return $this->handler->getRequest();
+    }
+}

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -3,11 +3,11 @@
 namespace JSHayes\FakeRequests;
 
 use GuzzleHttp\Psr7\Uri;
-use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use JSHayes\FakeRequests\Contracts\RequestHandler as RequestHandlerContract;
 
-class RequestHandler
+class RequestHandler implements RequestHandlerContract
 {
     private $callback;
     private $response;
@@ -23,7 +23,8 @@ class RequestHandler
         $this->uri = new Uri($uri);
         $this->path = ltrim($this->uri->getPath(), '/');
 
-        $this->respondWith(function () {});
+        $this->respondWith(function () {
+        });
         $this->when(function () {
             return true;
         });
@@ -96,9 +97,9 @@ class RequestHandler
      * it
      *
      * @param callable $callback
-     * @return \JSHayes\FakeRequests\RequestHandler
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
      */
-    public function inspectRequest(callable $callback): RequestHandler
+    public function inspectRequest(callable $callback): RequestHandlerContract
     {
         $this->callback = $callback;
         return $this;
@@ -108,9 +109,9 @@ class RequestHandler
      * Set the callback that determines when this request should be handled
      *
      * @param callable $callback
-     * @return \JSHayes\FakeRequests\RequestHandler
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
      */
-    public function when(callable $callback): RequestHandler
+    public function when(callable $callback): RequestHandlerContract
     {
         $this->when = $callback;
         return $this;
@@ -124,9 +125,9 @@ class RequestHandler
      *          ResponseInterface
      *          callable, @see respondWithCallback
      *          int, @see responseWithParameters
-     * @return \JSHayes\FakeRequests\RequestHandler
+     * @return \JSHayes\FakeRequests\Contracts\RequestHandler
      */
-    public function respondWith($arg): RequestHandler
+    public function respondWith($arg): RequestHandlerContract
     {
         if ($arg instanceof ResponseInterface) {
             $this->response = $arg;

--- a/tests/Doubles/Decorator.php
+++ b/tests/Doubles/Decorator.php
@@ -6,4 +6,13 @@ use JSHayes\FakeRequests\Decorator as BaseDecorator;
 
 class Decorator extends BaseDecorator
 {
+    /**
+     * An example decorated method to get the decoded request body
+     *
+     * @return array
+     */
+    public function getDecodedRequestBody(): array
+    {
+        return json_decode($this->getRequest()->getBody(), true);
+    }
 }

--- a/tests/Doubles/Decorator.php
+++ b/tests/Doubles/Decorator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Doubles;
+
+use JSHayes\FakeRequests\Decorator as BaseDecorator;
+
+class Decorator extends BaseDecorator
+{
+}

--- a/tests/Feature/MockHandlerTest.php
+++ b/tests/Feature/MockHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Tests\Doubles\Decorator;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use JSHayes\FakeRequests\MockHandler;
@@ -328,5 +329,19 @@ class MockHandlerTest extends TestCase
 
         $this->assertSame(200, $client->get('https://test.dev/test')->getStatusCode());
         $this->assertFalse($mockHandler->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_decorates_the_request_handler_when_a_decorator_is_set()
+    {
+        $client = $this->makeClient($mockHandler = new MockHandler());
+        $mockHandler->setDecorator(new Decorator());
+        $expectation = $mockHandler->expects('POST', '/test');
+
+        $this->assertSame(200, $client->post('https://test.dev/test', ['json' => ['key' => 'value']])->getStatusCode());
+
+        $this->assertEquals(['key' => 'value'], $expectation->getDecodedRequestBody());
     }
 }

--- a/tests/Unit/DecoratorTest.php
+++ b/tests/Unit/DecoratorTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests\Unit;
+
+use GuzzleHttp\Psr7\Request;
+use Tests\Doubles\Decorator;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use JSHayes\FakeRequests\RequestHandler;
+use JSHayes\FakeRequests\ResponseBuilder;
+
+class DecoratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function handle_returns_a_200_response_by_default()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $response = $handler->handle(new Request('GET', '/test'), []);
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', (string) $response->getBody());
+        $this->assertSame([], $response->getHeaders());
+    }
+
+    /**
+     * @test
+     */
+    public function you_can_add_a_custom_response()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $response = new Response();
+        $handler->respondWith($response);
+
+        $this->assertSame($response, $handler->handle(new Request('GET', '/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function you_can_customize_response_with_closure()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->respondWith(function (ResponseBuilder $builder) {
+            $builder->status(404);
+            $builder->body('test body');
+            $builder->headers(['header' => 'value']);
+        });
+        $response = $handler->handle(new Request('GET', '/test'), []);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('test body', (string) $response->getBody());
+        $this->assertSame(['header' => ['value']], $response->getHeaders());
+    }
+
+    /**
+     * @test
+     */
+    public function you_can_customize_response_with_parameters()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->respondWith(404, 'test body', ['header' => 'value']);
+        $response = $handler->handle(new Request('GET', '/test'), []);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('test body', (string) $response->getBody());
+        $this->assertSame(['header' => ['value']], $response->getHeaders());
+    }
+
+    /**
+     * @test
+     */
+    public function you_can_inspect_the_request_and_options()
+    {
+        $ran = false;
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->inspectRequest(function (RequestInterface $request, array $options) use (&$ran) {
+            $this->assertSame('GET', $request->getMethod());
+            $this->assertSame('/test', $request->getUri()->getPath());
+            $this->assertSame(['option' => 'value'], $options);
+            $ran = true;
+        });
+        $response = $handler->handle(new Request('GET', '/test'), ['option' => 'value']);
+
+        $this->assertTrue($ran);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_handle_requests_by_default()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $this->assertTrue($handler->shouldHandle(new Request('GET', '/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_handle_requests_when_the_when_condition_fails()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->when(function () {
+            return false;
+        });
+        $this->assertFalse($handler->shouldHandle(new Request('GET', '/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_handle_requests_when_the_when_condition_passes()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertTrue($handler->shouldHandle(new Request('GET', '/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function you_can_get_the_request_after_one_has_been_handled()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $request = new Request('GET', '/test');
+
+        $handler->handle($request, []);
+
+        $this->assertSame($request, $handler->getRequest()->getRequest());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_handle_requests_when_the_method_does_not_match()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertFalse($handler->shouldHandle(new Request('POST', '/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_handle_requests_when_the_path_does_not_match()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', '/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertFalse($handler->shouldHandle(new Request('GET', '/wat'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_handle_the_request_when_it_matches_the_host_and_path()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'http://test.dev/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertTrue($handler->shouldHandle(new Request('GET', 'http://test.dev/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_handle_the_request_when_it_does_not_match_the_host()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'http://test.dev/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertFalse($handler->shouldHandle(new Request('GET', 'http://incorrect.dev/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_handle_the_request_when_it_does_not_match_the_scheme()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'http://test.dev/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertFalse($handler->shouldHandle(new Request('GET', 'https://test.dev/test'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_handle_the_request_when_it_does_not_match_the_path()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'http://test.dev/test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertFalse($handler->shouldHandle(new Request('GET', 'http://test.dev/incorrect'), []));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_handle_the_request_when_the_path_does_not_have_a_preceeding_slash()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'test'));
+        $handler->when(function () {
+            return true;
+        });
+        $this->assertTrue($handler->shouldHandle(new Request('GET', '/test'), []));
+    }
+}

--- a/tests/Unit/DecoratorTest.php
+++ b/tests/Unit/DecoratorTest.php
@@ -234,4 +234,28 @@ class DecoratorTest extends TestCase
         });
         $this->assertTrue($handler->shouldHandle(new Request('GET', '/test'), []));
     }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_uri()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'http://test.dev/test'));
+
+        $this->assertSame('http', $handler->getUri()->getScheme());
+        $this->assertSame('test.dev', $handler->getUri()->getHost());
+        $this->assertSame('/test', $handler->getUri()->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_method()
+    {
+        $decorator = new Decorator();
+        $handler = $decorator->decorate(new RequestHandler('GET', 'http://test.dev/test'));
+
+        $this->assertSame('GET', $handler->getMethod());
+    }
 }

--- a/tests/Unit/MockHandlerTest.php
+++ b/tests/Unit/MockHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use GuzzleHttp\Psr7\Request;
+use Tests\Doubles\Decorator;
 use PHPUnit\Framework\TestCase;
 use JSHayes\FakeRequests\MockHandler;
 use JSHayes\FakeRequests\RequestHandler;
@@ -110,5 +111,16 @@ class MockHandlerTest extends TestCase
         $handler($request, []);
 
         $this->assertTrue($handler->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function setting_a_decorator_decorates_that_request_handler()
+    {
+        $handler = new MockHandler();
+        $handler->setDecorator(new Decorator());
+
+        $this->assertInstanceOf(Decorator::class, $handler->expects('get', '/test'));
     }
 }


### PR DESCRIPTION
Adds decorators to the request handlers. This can be used to decorate the request handler to add assertion helper methods for your tests.